### PR TITLE
Gcnv 42 cnv vep config

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Json configuration file for CEN assay CNV variant annotation using VEP.
 
 Configuration file required to annotate a vcf using [Variant Effect Predictor](https://github.com/Ensembl/ensembl-vep) implementation [eggd_vep](https://github.com/eastgenomics/eggd_vep).
 
-A variable level of annotation can be achieved by different combinations of custom annotation , vep plugins in addition to the required VEP resources.
+A variable level of annotation can be achieved by different combinations of custom annotation, vep plugins in addition to the required VEP resources.
 
 ## What does this config version contain?
 
-This json file provides information about annotations,plugins, required fields and the genome version.
+This json file provides information about annotations, plugins, required fields and the genome version.
 
 * Genome build: GRCh37
 * VEP required files:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
 # eggd_vep_CENCNV_config
-Json configuration file for CEN CNV annotation using VEP.
+Json configuration file for CEN assay CNV variant annotation using VEP.
+
+## What does this config do?
+
+Configuration file required to annotate a vcf using [Variant Effect Predictor](https://github.com/Ensembl/ensembl-vep) implementation [eggd_vep](https://github.com/eastgenomics/eggd_vep).
+
+A variable level of annotation can be achieved by different combinations of custom annotation , vep plugins in addition to the required VEP resources.
+
+## What does this config version contain?
+
+This json file provides information about annotations,plugins, required fields and the genome version.
+
+* Genome build: GRCh37
+* VEP required files:
+  * vep_v105.0.tar.gz
+  * plugin_config.txt
+  * homo_sapiens_refseq_vep_105_GRCh37.tar.gz
+  * Homo_sapiens.GRCh37.dna.toplevel.fa.gz
+  * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai
+  * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi
+  * hs37d5.fasta-index.tar.gz
+* Custom Annotation sources:
+  * None for CNV analysis at the moment.
+
+
+## Notes
+  How to check the names of all the files included in the config:
+
+```bash
+config_file=you_file_name.json
+
+# Get the Vep Resources filenames
+for file in  $(jq -r ' .vep_resources | .[]' $config_file);
+do dx describe $file --json | jq -r '.name';
+done
+
+# Get Custom Annotation filenames
+for file in  $(jq -r ' .custom_annotations[]|.resource_files[]|.file_id' $config_file);
+do dx describe $file --json | jq -r '.name';
+done
+
+# Get Plugin Annotation filenames
+for file in  $(jq -r ' .plugins[]|.resource_files[]|.file_id' $config_file);
+do dx describe $file --json | jq -r '.name';
+done
+
+```
+
+

--- a/cen-cnv_config_v1.0.0.json
+++ b/cen-cnv_config_v1.0.0.json
@@ -1,0 +1,31 @@
+ {
+    "config_information":{
+        "genome_build": "GRCh37",
+        "assay":"CEN-CNV",
+        "config_version": "1.0.0"
+    },
+        "vep_resources":{
+        "vep_docker":"project-Fkb6Gkj433GVVvj73J7x8KbV:file-G8V2Vz0433Gp5bYPF2f6vg9X",
+        "plugin_config":"project-Fkb6Gkj433GVVvj73J7x8KbV:file-G9jZpk8433GvFvX14P775324",
+        "vep_cache":"project-Fkb6Gkj433GVVvj73J7x8KbV:file-G8V4bGj433Gz96K3Fb1VfbG3",
+        "reference_fasta":"project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYyyj4YV3pYBkgFVGP2K4P",
+        "reference_fai":"project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6P32kj4YV3y58KyP4k4qG2p",
+        "reference_gzi":"project-Fkb6Gkj433GVVvj73J7x8KbV:file-G6BYz104YV3X5qp463K5b5vp",
+        "ref_bcftools":"project-Fkb6Gkj433GVVvj73J7x8KbV:file-F3zxG0Q4fXX9YFjP1v5jK9jf"
+    },
+    "custom_annotations": [
+    ],
+    "plugins": [
+    ],
+    "additional_fields":[
+        "Allele",
+        "SYMBOL",
+        "VARIANT_CLASS",
+        "Consequence",
+        "IMPACT",
+        "EXON",
+        "INTRON",
+        "Feature",
+        "STRAND"
+    ]
+  }


### PR DESCRIPTION
VEP Config for CNV annotation for the CEN assay. 

Based on the cen vep config and removed custom_annotations and plugins as not useful for CNVs. 
Also removed fields not yielding any results namely, all HGVS fields and Existing variation.

Job to show it works: https://platform.dnanexus.com/projects/GFPFjZQ4GVVKypPy26q2KxB5/monitor/job/GGkJxXj4GVV145fb3K41Jkxv

How it was created: https://cuhbioinformatics.atlassian.net/wiki/spaces/C/pages/2790555845/CEN-CNV+VEP+config+v1.0.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_cencnv_config/1)
<!-- Reviewable:end -->
