### PR TITLE
DI-1401 Update to add GRCh38 VEP CEN CNV config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # eggd_vep_CENCNV_config
+
 Json configuration file for CEN assay CNV variant annotation using VEP.
 
 ## What does this config do?
@@ -9,26 +10,26 @@ A variable level of annotation can be achieved by different combinations of cust
 
 ## What does this config version contain?
 
-This json file provides information about annotations, plugins, required fields and the genome version.
+This config repo contains two json files for the genome builds GRCh38 and GRCh37.
+These json files provides information about annotations, plugins, required fields and the genome version.
 
-* Genome build: GRCh37
-* VEP required files:
-  * vep_v107.0.tar.gz
-  * plugin_config.txt
-  * homo_sapiens_refseq_vep_107_GRCh37.tar.gz
-  * Homo_sapiens.GRCh37.dna.toplevel.fa.gz
-  * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai
-  * Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi
-  * hs37d5.fasta-index.tar.gz
-* Custom Annotation sources:
-  * None for CNV analysis at the moment.
-
+| Key | GRCh37 | GRCh38 |
+|--------------|--------------|--------------|
+| **vep_docker** | vep_v107.0.tar.gz | vep_v107.0.tar.gz |
+| **plugin_config** | plugin_config.txt | plugin_config.txt |
+| **vep_cache** | homo_sapiens_refseq_vep_107_GRCh37.tar.gz | homo_sapiens_refseq_vep_107_GRCh38.tar.gz |
+| **reference_fasta** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz | Homo_sapiens.GRCh38.dna.toplevel.fa.gz |
+| **reference_fai** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.fai | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.fai |
+| **reference_gzi** | Homo_sapiens.GRCh37.dna.toplevel.fa.gz.gzi | Homo_sapiens.GRCh38.dna.toplevel.fa.gz.gzi |
+| **ref_bcftools** | hs37d5.fasta-index.tar.gz | GRCh38_GIABv3_no_alt_analysis_set_maskedGRC_decoys_MAP2K3_KMT2C_KCNJ18_noChr.fasta-index.tar.gz |
+| **Custom Annotation sources** | No custom annotation for CNV analysis currently | No custom annotation for CNV analysis currently |
 
 ## Notes
+
   How to check the names of all the files included in the config:
 
 ```bash
-config_file=you_file_name.json
+config_file=<config_filename>.json
 
 # Get the Vep Resources filenames
 for file in  $(jq -r ' .vep_resources | .[]' $config_file);
@@ -46,5 +47,3 @@ do dx describe $file --json | jq -r '.name';
 done
 
 ```
-
-

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A variable level of annotation can be achieved by different combinations of cust
 ## What does this config version contain?
 
 This config repo contains two json files for the genome builds GRCh38 and GRCh37.
-These json files provides information about annotations, plugins, required fields and the genome version.
+These json files provide information about annotations, plugins, required fields and the genome version.
 
 | Key | GRCh37 | GRCh38 |
 |--------------|--------------|--------------|

--- a/cen-cnv_config_GRCh38_v1.0.0.json
+++ b/cen-cnv_config_GRCh38_v1.0.0.json
@@ -1,0 +1,31 @@
+ {
+    "config_information":{
+        "genome_build": "GRCh38",
+        "assay":"CEN-CNV",
+        "config_version": "1.0.0"
+    },
+        "vep_resources":{
+        "vep_docker":"file-GQ7Z9y84xyx28bzFGx5jkxkG",
+        "plugin_config":"file-GQ7Yzz04XB7q1vZyY9pQGyjp",
+        "vep_cache":"file-GQ7Yqpj4qpBvpby694GgX92x",
+        "reference_fasta":"file-G61y95Q433Gk05zyFKF9kFv2",
+        "reference_fai":"file-G61yBV8433GjbVj022PyV3K5",
+        "reference_gzi":"file-G61yBf0433Gp4BBVGj0jxqvP",
+        "ref_bcftools":"file-Gb772VQ4XGyzQ0Zk615XbZ0X"
+    },
+    "custom_annotations": [
+    ],
+    "plugins": [
+    ],
+    "additional_fields":[
+        "Allele",
+        "SYMBOL",
+        "VARIANT_CLASS",
+        "Consequence",
+        "IMPACT",
+        "EXON",
+        "INTRON",
+        "Feature",
+        "STRAND"
+    ]
+  }


### PR DESCRIPTION
Documentation updates:
* `README.md`: Updated the description to reflect the inclusion of two JSON configuration files for genome builds GRCh37 and GRCh38. Added a comparison table to detail the VEP resources and custom annotation sources for both genome builds.

Configuration updates:

* `cen-cnv_config_GRCh38_v1.0.0.json`: Added a new JSON configuration file for the GRCh38 genome build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vep_CENCNV_config/4)
<!-- Reviewable:end -->
